### PR TITLE
Added a method to get VgcPeripheral to retrieve the connectedService from the VgcBrowser

### DIFF
--- a/Source/Framework/VgcPeripheral.swift
+++ b/Source/Framework/VgcPeripheral.swift
@@ -200,6 +200,13 @@ public class Peripheral: NSObject, VgcWatchDelegate {
         
     }
     
+    public var connectedService: VgcService? {
+        get {
+            guard let service = browser.connectedVgcService else { return nil }
+            return service
+        }
+    }
+    
     public var availableServices: [VgcService] {
         get {
             let services = [VgcService](browser.serviceLookup.values)


### PR DESCRIPTION
Added a method to get a Peripheral's connectedService. Can be used to retrieve
details about the service, such as the name.
