### PR TITLE
Excluded the VgcCentralViewController from the tvos target

### DIFF
--- a/VirtualGameController.podspec.json
+++ b/VirtualGameController.podspec.json
@@ -22,7 +22,10 @@
     "osx": "10.10"
   },
   "tvos": {
-    "exclude_files": "Source/**/VgcCentralPublisherWatch.swift"
+    "exclude_files": [
+      "Source/**/VgcCentralPublisherWatch.swift",
+      "Source/**/VgcCentralViewController.swift"
+    ]
   },
   "osx": {
     "exclude_files": [


### PR DESCRIPTION
The tv target fails to build in as there are unavailable methods in the VgcCentralViewController
